### PR TITLE
Add a `DeleteOne` variant constructor

### DIFF
--- a/bs.deriving.md
+++ b/bs.deriving.md
@@ -80,6 +80,7 @@ Similarly, imagine your new Reason code has the following variant:
 type action =
   | Add(string)
   | Toggle(int)
+  | Delete(int)
   | DeleteAll;
 ```
 
@@ -92,6 +93,7 @@ By adding `bs.deriving accessors`, you get a creation function for every variant
 type action =
   | Add(string)
   | Toggle(int)
+  | Delete(int)
   | DeleteAll;
 ```
 
@@ -100,7 +102,8 @@ Now, in JS you can do:
 ```js
 let actions = [
   add("Drink coffee"), 
-  toggle(34), 
+  toggle(34),
+  delete(12),
   deleteAll
 ];
 ```

--- a/bs.deriving.md
+++ b/bs.deriving.md
@@ -80,11 +80,11 @@ Similarly, imagine your new Reason code has the following variant:
 type action =
   | Add(string)
   | Toggle(int)
-  | Delete(int)
+  | DeleteOne(int)
   | DeleteAll;
 ```
 
-and you want to create `Delete(12)` from JS, for example.
+and you want to create `DeleteOne(12)` from JS, for example.
 
 By adding `bs.deriving accessors`, you get a creation function for every variant constructor.
 
@@ -93,7 +93,7 @@ By adding `bs.deriving accessors`, you get a creation function for every variant
 type action =
   | Add(string)
   | Toggle(int)
-  | Delete(int)
+  | DeleteOne(int)
   | DeleteAll;
 ```
 
@@ -103,7 +103,7 @@ Now, in JS you can do:
 let actions = [
   add("Drink coffee"), 
   toggle(34),
-  delete(12),
+  deleteOne(12),
   deleteAll
 ];
 ```


### PR DESCRIPTION
We have a `DeteleAll` variant constructor but no `DeleteOne` which I think would be great addition to the example list.

.